### PR TITLE
Switch to attachment.type for Content-Type

### DIFF
--- a/lib/GCS.js
+++ b/lib/GCS.js
@@ -60,7 +60,7 @@ GCSStorageProvider.prototype.save = function(attachment, callback) {
 
   this._client.putStream(fs.createReadStream(attachment.path), this._options.bucket, this._options.path(attachment), {
     'Content-Length': attachment.size,
-    'Content-Type': attachment.mimeType,
+    'Content-Type': attachment.type,
     'x-goog-acl': this._options.acl
   }, function(error, response) {
     callback(error, error ? undefined : response.request.href)


### PR DESCRIPTION
In https://github.com/achingbrain/mongoose-crate/commit/1435bdb8f792790fe5a388bdb96f1a0fe5092345, the property was renamed to `type`. This makes Google Cloud Storage work correctly again, resolving the following error (caused by trying to set Content-Type to undefined):

```
_http_outgoing.js:333
    throw new Error('"name" and "value" are required for setHeader().');
          ^
Error: "name" and "value" are required for setHeader().
    at ClientRequest.OutgoingMessage.setHeader (_http_outgoing.js:333:11)
    at new ClientRequest (_http_client.js:101:14)
    at Object.exports.request (http.js:49:10)
    at Request.start (/x/node_modules/mongoose-crate-gcs/node_modules/node-gcs/node_modules/request/main.js:559:30)
    at Request.write (/x/node_modules/mongoose-crate-gcs/node_modules/node-gcs/node_modules/request/main.js:1070:28)
    at ReadStream.ondata (_stream_readable.js:540:20)
    at ReadStream.emit (events.js:107:17)
    at ReadStream.Readable.read (_stream_readable.js:373:10)
    at flow (_stream_readable.js:750:26)
    at resume_ (_stream_readable.js:730:3)
    at _stream_readable.js:717:7
    at process._tickDomainCallback (node.js:381:11)
```

Cheers & thanks for the great library!
